### PR TITLE
use thrift-serializer

### DIFF
--- a/src/braze-upload/lambda/lambda.ts
+++ b/src/braze-upload/lambda/lambda.ts
@@ -1,18 +1,16 @@
 const AWS = require('aws-sdk');
-const Thrift = require('thrift');
 const acquisition_types = require('../gen-nodejs/acquisition_types');
+const serializer = require('thrift-serializer');
 
 export async function handler(event: any, context: any): Promise<null> {
     console.log("events:", JSON.stringify(event));
     event.Records.map(record => {
-        const payload = new Buffer(record.kinesis.data, 'base64');
-        console.log("payload", payload);
-        const transport = new Thrift.TFramedTransport(payload);
-        const protocol = new Thrift.TCompactProtocol(transport);
-        const acquisition = new acquisition_types.Acquisition();
-
-        const result = acquisition.read(protocol);
-        console.log("result",result)
+        serializer.read(acquisition_types.Acquisition, record.kinesis.data, function (err, msg) {
+            if (err) {
+                console.log("error", err)
+            }
+            console.log("result", JSON.stringify(msg));
+        });
     });
     return Promise.resolve(null);
 }

--- a/src/braze-upload/lambda/local.ts
+++ b/src/braze-upload/lambda/local.ts
@@ -1,6 +1,8 @@
 import { handler } from "./lambda";
+import {logInfo} from "../../lib/log";
 
 const AWS = require('aws-sdk');
+const fs = require('fs');
 
 process.env.AWS_PROFILE = 'membership';
 const credentials = new AWS.SharedIniFileCredentials({profile: 'membership'});
@@ -10,13 +12,21 @@ AWS.config.region = 'eu-west-1';
 
 async function run() {
     process.env.Stage = 'DEV';
-    await handler({}, null)
-        .then(result => {
-            console.log('Result: ', result);
-        })
-        .catch(err => {
-            console.log('Failed to run locally: ', err);
-        })
+
+    try {
+        const fileContents = fs.readFileSync('./test-event.json', 'utf8');
+        const input = JSON.parse(fileContents);
+
+        await handler(input, null)
+            .then(result => {
+                console.log('Result: ', result);
+            })
+            .catch(err => {
+                console.log('Failed to run locally: ', err);
+            })
+    } catch (err) {
+        logInfo(`error parsing test event file`, err);
+    }
 }
 
 run();

--- a/src/braze-upload/package.json
+++ b/src/braze-upload/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "aws-sdk": "^2.264.1",
     "moment": "2.22.2",
-    "thrift": "0.9.3",
+    "thrift-serializer": "^1.1.0",
     "typescript": "2.8.3"
   },
   "devDependencies": {
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "rm -rf target",
     "build": "tsc",
-    "local": "node target/lambda/local.js",
+    "local": "npm run build && node target/braze-upload/lambda/local.js",
     "package": "ARTEFACT_PATH=$PWD/target VERBOSE=true riffraff-artefact"
   }
 }

--- a/src/braze-upload/test-event.json
+++ b/src/braze-upload/test-event.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "200003565",
+        "sequenceNumber": "49606363767759761293652286008102082150550133262965014530",
+        "data": "ABUEFQQYA0dCUBcAAAAAAAAgQCUCLBpMGA11a0Ftb3VudHNUZXN0GAJWMQAYEW5ld1RoYW5rWW91Rmxvd1IxGAduZXdGbG93ABgPbmV3VGhhbmtZb3VGbG93GAduZXdGbG93ABgUc3RyaXBlRnJhdWREZXRlY3Rpb24YB1ZhcmlhbnQAABgCR0KlIEoIGAkyMDAwMDM1NjUaDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "approximateArrivalTimestamp": 1600180409.23
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:49606363767759761293652286008102082150550133262965014530",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::865473395570:role/contributions-referrals-braz-BrazeUploadLambdaRole-1XP8W1RZU1BB",
+      "awsRegion": "eu-west-1",
+      "eventSourceARN": "arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-CODE"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a test kinesis event for running locally.
Also uses the `thrift-serializer` library (my own implementation was failing, probably because of compression)