### PR TITLE
do not retry processing a kinesis event after failure

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -169,6 +169,7 @@ Resources:
             Stream: !Ref StreamArn
             BatchSize: 10
             StartingPosition: LATEST
+            MaximumRetryAttempts: 0
 
   DomainName:
     Type: "AWS::ApiGateway::DomainName"


### PR DESCRIPTION
To avoid blocking the stream when an event cannot be processed successfully.
A lambda failure will trigger an alarm, and the referralCode of the failed event will be in the log. At that point we can investigate