### PR TITLE
script for manually sending a referralCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clean": "rm -rf target",
     "build": "tsc",
     "braze-upload-local": "npm run build && node target/braze-upload/lambda/local.js",
+    "braze-upload-local-referral-code": "npm run build && node target/braze-upload/lambda/localForReferralCode.js",
     "create-code-local": "npm run build && node target/create-code/lambda/local.js",
     "referral-count-local": "npm run build && node target/referral-count/lambda/local.js",
     "package": "ARTEFACT_PATH=$PWD/target VERBOSE=true riffraff-artefact"

--- a/src/braze-upload/lambda/lambda.ts
+++ b/src/braze-upload/lambda/lambda.ts
@@ -63,9 +63,45 @@ const getReferralCodeFromThriftBytes = (rawThriftData: any): Promise<string | nu
         });
     });
 
-export async function handler(event: Event, context: any): Promise<any> {
-    const config = await lambdaConfigPromise;
+export const processReferralCode = async (referralCode: string): Promise<void> => {
+    logInfo(`Processing referralCode ${referralCode}`);
+
     const pool = await dbConnectionPool;
+    const config = await lambdaConfigPromise;
+
+    // Fetch the braze uuid
+    const referralDataLookupResult: QueryResult = await fetchReferralData(referralCode, pool);
+
+    const referralData = referralDataLookupResult.rows[0];
+    if (!referralData) {
+        return Promise.reject(`No brazeUuid found for referralCode ${referralCode}`);
+    }
+
+    // Write the successful referral
+    const writeResult: QueryResult = await writeSuccessfulReferral(
+        {
+            brazeUuid: referralData.braze_uuid,
+            referralCode: referralCode,
+            campaignId: referralData.campaign_id,
+        },
+        pool
+    );
+    if (writeResult.rows.length <= 0) {
+        return Promise.reject(`Failed to write successful referral for code ${referralCode}`);
+    }
+
+    // Fetch the distinct set of campaignIds for this braze user
+    const campaignIdsResult: QueryResult = await fetchCampaignIds(referralData.braze_uuid, pool);
+    if (campaignIdsResult.rows.length <= 0) {
+        return Promise.reject(`No campaignIds found for brazeUuid ${referralData.braze_uuid}`);
+    }
+
+    const campaignIds = campaignIdsResult.rows.map(row => row.campaign_id);
+
+    return sendCampaignIdsToBraze(campaignIds, referralData.braze_uuid, config.brazeKey);
+};
+
+export async function handler(event: Event, context: any): Promise<any> {
 
     const maybeReferralCodes: (string | null)[] = await Promise.all(
         event.Records.map(record => getReferralCodeFromThriftBytes(record.kinesis.data))
@@ -74,40 +110,7 @@ export async function handler(event: Event, context: any): Promise<any> {
     const resultPromises = maybeReferralCodes
         .filter(maybeReferralCode => !!maybeReferralCode)
         .map(c => c as string)  // typescript doesn't know that the above line filters to strings only
-        .map(async (referralCode: string) => {
-            logInfo(`Processing referralCode ${referralCode}`);
-
-            // Fetch the braze uuid
-            const referralDataLookupResult: QueryResult = await fetchReferralData(referralCode, pool);
-
-            const referralData = referralDataLookupResult.rows[0];
-            if (!referralData) {
-                return Promise.reject(`No brazeUuid found for referralCode ${referralCode}`);
-            }
-
-            // Write the successful referral
-            const writeResult: QueryResult = await writeSuccessfulReferral(
-                {
-                    brazeUuid: referralData.braze_uuid,
-                    referralCode: referralCode,
-                    campaignId: referralData.campaign_id,
-                },
-                pool
-            );
-            if (writeResult.rows.length <= 0) {
-                return Promise.reject(`Failed to write successful referral for code ${referralCode}`);
-            }
-
-            // Fetch the distinct set of campaignIds for this braze user
-            const campaignIdsResult: QueryResult = await fetchCampaignIds(referralData.braze_uuid, pool);
-            if (campaignIdsResult.rows.length <= 0) {
-                return Promise.reject(`No campaignIds found for brazeUuid ${referralData.braze_uuid}`);
-            }
-
-            const campaignIds = campaignIdsResult.rows.map(row => row.campaign_id);
-
-            return sendCampaignIdsToBraze(campaignIds, referralData.braze_uuid, config.brazeKey);
-        });
+        .map(processReferralCode);
 
     return Promise.all(resultPromises);
 }

--- a/src/braze-upload/lambda/localForReferralCode.ts
+++ b/src/braze-upload/lambda/localForReferralCode.ts
@@ -1,8 +1,7 @@
-import { handler } from "./lambda";
+import {processReferralCode} from "./lambda";
 import {logInfo} from "../../lib/log";
 
 const AWS = require('aws-sdk');
-const fs = require('fs');
 
 process.env.AWS_PROFILE = 'membership';
 const credentials = new AWS.SharedIniFileCredentials({profile: 'membership'});
@@ -10,14 +9,15 @@ const credentials = new AWS.SharedIniFileCredentials({profile: 'membership'});
 AWS.config.credentials = credentials;
 AWS.config.region = 'eu-west-1';
 
+
+const referralCode = process.argv[2];
+console.log("referralCode", referralCode)
+
 async function run() {
     process.env.Stage = 'DEV';
 
     try {
-        const fileContents = fs.readFileSync('./src/braze-upload/test-event.json', 'utf8');
-        const input = JSON.parse(fileContents);
-
-        handler(input, null)
+        await processReferralCode(referralCode)
             .then(result => {
                 console.log('Result: ', result);
             })


### PR DESCRIPTION
the diff is big but all this does is move code out into a new function called `processReferralCode` so that it can be called by a new script, `localForReferralCode.ts`

This is so that we can re-play referrals after the referralCode had previously failed to go into the database