### PR TITLE
Fetch braze-upload config sequentially

### DIFF
--- a/src/braze-upload/lambda/lambda.ts
+++ b/src/braze-upload/lambda/lambda.ts
@@ -30,6 +30,7 @@ const getLambdaConfig = async (): Promise<LambdaConfig> => {
     }
 };
 const lambdaConfigPromise: Promise<LambdaConfig> = getLambdaConfig();
+// It is important for the DB connection to be created in the global scope, otherwise we create one for each lambda invocation
 const dbConnectionPool: Promise<Pool> = lambdaConfigPromise
     .then(config => createDatabaseConnectionPool(config.dbConfig));
 

--- a/src/braze-upload/lambda/lambda.ts
+++ b/src/braze-upload/lambda/lambda.ts
@@ -6,8 +6,8 @@ import {
     writeSuccessfulReferral
 } from "../lib/db";
 import {getDatabaseParamsFromSSM} from "../../lib/ssm";
-import {sendCampaignIdsToBraze} from "../lib/braze";
-import {createDatabaseConnectionPool} from "../../lib/db";
+import {getBrazeKeyFromSsm, sendCampaignIdsToBraze} from "../lib/braze";
+import {createDatabaseConnectionPool, DBConfig} from "../../lib/db";
 import {logInfo} from "../../lib/log";
 
 const AWS = require('aws-sdk');
@@ -15,7 +15,23 @@ const acquisition_types = require('../gen-nodejs/acquisition_types');
 const serializer = require('thrift-serializer');
 
 const ssm: SSM = new AWS.SSM({region: 'eu-west-1'});
-const dbConnectionPool: Promise<Pool> =  getDatabaseParamsFromSSM(ssm).then(createDatabaseConnectionPool);
+
+interface LambdaConfig {
+    dbConfig: DBConfig,
+    brazeKey: string,
+}
+
+const getLambdaConfig = async (): Promise<LambdaConfig> => {
+    const dbConfig = await getDatabaseParamsFromSSM(ssm);
+    const brazeKey = await getBrazeKeyFromSsm(ssm);
+    return {
+        dbConfig,
+        brazeKey
+    }
+};
+const lambdaConfigPromise: Promise<LambdaConfig> = getLambdaConfig();
+const dbConnectionPool: Promise<Pool> = lambdaConfigPromise
+    .then(config => createDatabaseConnectionPool(config.dbConfig));
 
 interface Event {
     Records: {
@@ -47,6 +63,7 @@ const getReferralCodeFromThriftBytes = (rawThriftData: any): Promise<string | nu
     });
 
 export async function handler(event: Event, context: any): Promise<any> {
+    const config = await lambdaConfigPromise;
     const pool = await dbConnectionPool;
 
     const maybeReferralCodes: (string | null)[] = await Promise.all(
@@ -88,7 +105,7 @@ export async function handler(event: Event, context: any): Promise<any> {
 
             const campaignIds = campaignIdsResult.rows.map(row => row.campaign_id);
 
-            return sendCampaignIdsToBraze(campaignIds, referralData.braze_uuid);
+            return sendCampaignIdsToBraze(campaignIds, referralData.braze_uuid, config.brazeKey);
         });
 
     return Promise.all(resultPromises);

--- a/src/braze-upload/lib/braze.ts
+++ b/src/braze-upload/lib/braze.ts
@@ -2,17 +2,14 @@ import {getParamFromSSM, ssmStage} from "../../lib/ssm";
 import SSM = require("aws-sdk/clients/ssm");
 import fetch from "node-fetch";
 
-const AWS = require('aws-sdk');
-const ssm: SSM = new AWS.SSM({region: 'eu-west-1'});
-
 const brazeEndpoint = "https://rest.fra-01.braze.eu/users/track";
 
-const brazeKeyPromise: Promise<string> = getParamFromSSM(ssm, `/contributions-referrals/braze/${ssmStage}/api-key`);
+export const getBrazeKeyFromSsm = (ssm: SSM): Promise<string> =>
+    getParamFromSSM(ssm, `/contributions-referrals/braze/${ssmStage}/api-key`);
 
-export const sendCampaignIdsToBraze = async (campaignIds: string[], brazeUuid: string): Promise<any> => {
-    const key = await brazeKeyPromise;
+export const sendCampaignIdsToBraze = async (campaignIds: string[], brazeUuid: string, brazeKey: string): Promise<any> => {
     const requestBody = {
-        api_key: key,
+        api_key: brazeKey,
         attributes: [{
             external_id: brazeUuid,
             unmanaged_contribution_referral_campaign_ids: campaignIds


### PR DESCRIPTION
This lambda sometimes fails on startup with a network failure while making a request to SSM:
`NetworkingError: Client network socket disconnected before secure TLS connection was established`

The only difference between this lambda and our other lambdas which depend on SSM is that it makes 2 separate requests to SSM, potentially concurrently.
With this PR, the lambda now makes the 2 SSM requests sequentially and builds a `LambdaConfig` object.