### PR TITLE
re-order dependency awaits

### DIFF
--- a/src/braze-upload/lambda/lambda.ts
+++ b/src/braze-upload/lambda/lambda.ts
@@ -66,8 +66,8 @@ const getReferralCodeFromThriftBytes = (rawThriftData: any): Promise<string | nu
 export const processReferralCode = async (referralCode: string): Promise<void> => {
     logInfo(`Processing referralCode ${referralCode}`);
 
-    const pool = await dbConnectionPool;
     const config = await lambdaConfigPromise;
+    const pool = await dbConnectionPool;
 
     // Fetch the braze uuid
     const referralDataLookupResult: QueryResult = await fetchReferralData(referralCode, pool);


### PR DESCRIPTION
I'm not sure this really matters in practice, but the `dbConnectionPool` promise depends on the `lambdaConfigPromise` promise.
(these promises are in the global scope because they should be shared across lambda invocations)