### PR TITLE
disable kinesis event

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -272,14 +272,17 @@ Resources:
             Action: s3:GetObject
             Resource:
               - arn:aws:s3::*:membership-dist/*
-      Events:
-        Stream:
-          Type: Kinesis
-          Properties:
-            Stream: !Ref StreamArn
-            BatchSize: 10
-            StartingPosition: LATEST
-            MaximumRetryAttempts: 0
+# Kinesis event disabled because the stream now sends JSON, not thrift.
+# If this lambda is used again then it will need to be migrated to use the new JSON model:
+# https://github.com/guardian/support-frontend/blob/main/support-modules/acquisition-events/src/main/scala/com/gu/support/acquisitions/models/AcquisitionDataRow.scala#L14
+#      Events:
+#        Stream:
+#          Type: Kinesis
+#          Properties:
+#            Stream: !Ref StreamArn
+#            BatchSize: 10
+#            StartingPosition: LATEST
+#            MaximumRetryAttempts: 0
 
   DomainName:
     Type: "AWS::ApiGateway::DomainName"


### PR DESCRIPTION
We're not currently using the referrals system.
The braze-upload lambda is currently broken because it expects to receive events from kinesis as thrift.
We've since migrated the stream to json.
For now I've just disabled the event, to stop the alarm from going off. I don't think it's worth migrating until we know we want to use referrals again.